### PR TITLE
Show direct links before giving consent, allow usage without JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The plugin was mainly developed to aid [**CookieConsent**](https://github.com/or
   - lazyloads thumbnails
   - lazyloads iframes
 - Can be integrated with any cookie consent solution
+- Allows external links to services without JS enabled or without giving consent
 
 ## Installation
 1. #### Download the [latest release](https://github.com/orestbida/iframemanager/releases/latest) or use via CDN:
@@ -98,6 +99,7 @@ The plugin was mainly developed to aid [**CookieConsent**](https://github.com/or
                     currLang: 'en',
                     services : {
                         youtube : {
+                            name: 'YouTube',
                             embedUrl: 'https://www.youtube-nocookie.com/embed/{data-id}',
                             thumbnailUrl: 'https://i3.ytimg.com/vi/{data-id}/hqdefault.jpg',
                             iframe : {
@@ -110,7 +112,8 @@ The plugin was mainly developed to aid [**CookieConsent**](https://github.com/or
                                 en : {
                                     notice: 'This content is hosted by a third party. By showing the external content you accept the <a rel="noreferrer" href="https://www.youtube.com/t/terms" title="Terms and conditions" target="_blank">terms and conditions</a> of youtube.com.',
                                     loadBtn: 'Load video',
-                                    loadAllBtn: 'Don\'t ask again'
+                                    loadAllBtn: 'Don\'t ask again',
+                                    openBtn: 'Watch on YouTube'
                                 }
                             }
                         }
@@ -139,6 +142,7 @@ The plugin was mainly developed to aid [**CookieConsent**](https://github.com/or
                     currLang: 'en',
                     services : {
                         youtube : {
+                            name: 'YouTube',
                             embedUrl: 'https://www.youtube-nocookie.com/embed/{data-id}',
                             thumbnailUrl: 'https://i3.ytimg.com/vi/{data-id}/hqdefault.jpg',
                             iframe : {
@@ -151,7 +155,8 @@ The plugin was mainly developed to aid [**CookieConsent**](https://github.com/or
                                 en : {
                                     notice: 'This content is hosted by a third party. By showing the external content you accept the <a rel="noreferrer" href="https://www.youtube.com/t/terms" title="Terms and conditions" target="_blank">terms and conditions</a> of youtube.com.',
                                     loadBtn: 'Load video',
-                                    loadAllBtn: 'Don\'t ask again'
+                                    loadAllBtn: 'Don\'t ask again',
+                                    openBtn: 'Watch on YouTube'
                                 }
                             }
                         }
@@ -171,14 +176,18 @@ The plugin was mainly developed to aid [**CookieConsent**](https://github.com/or
     ```
 
 ## Configuration options
-All available options for  the `<div>` element:
+All available options for  the `<div>` element (you can use any element):
 ```html
 <div
     data-service="<service-name>"	
     data-id="<resource-id>"
     data-params="<iframe-query-parameters>"
     data-thumbnail="<path-to-image>" 
+    data-open-url="<public-url>"
+    data-ratio="<y:x>"
+    data-style="<css-style>"
     data-autoscale>
+        This is inline HTML which will be removed when JS is allowed. You can use this space to link the public URL, for example <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" target="_blank" rel="noopener">like this</a>. Your website will then be more accessible, plus you will get an automatic open link so you don't need to fill `data-open-url`.
 </div>
 ```
 
@@ -186,7 +195,9 @@ All available options for  the `<div>` element:
 - `data-id` :           [String, Required] unique id of the resource (example: video id)
 - `data-params` :       [String] iframe query parameters
 - `data-thumbnail` :    [String] path to custom thumbnail
+- `data-open-url` :     [String] link to the non-embed URL (example: `https://www.youtube.com/watch?v=dQw4w9WgXcQ`)
 - `data-ratio` :        [String] aspect ratio ([supported aspect ratios](#aspect-ratios))
+- `data-style` :        [String] CSS to be applied when JavaScript is enabled
 - `data-autoscale` :    specify for **responsive iframe** (fill parent width + scale proportionally)
 
 <br>
@@ -200,7 +211,7 @@ All available options for the config. object:
 
     services : {
         myservice : {
-
+            name: 'My Service',
             embedUrl: 'https://myservice_embed_url>/{data-id}',
 
             // set valid url for automatic thumbnails   [OPTIONAL]
@@ -229,7 +240,8 @@ All available options for the config. object:
                 en : {
                     notice: 'Html <b>notice</b> message',
                     loadBtn: 'Load video',          // Load only current iframe
-                    loadAllBtn: 'Don\'t ask again'  // Load all iframes configured with this service + set cookie		
+                    loadAllBtn: 'Don\'t ask again', // Load all iframes configured with this service + set cookie
+                    openBtn: 'Watch on YouTube'     // Text for the direct link before giving consent, defaults to "Open <service-name>"
                 }
             }
         },
@@ -294,7 +306,9 @@ Both `acceptService` and `rejectService` work the same way:
         currLang: 'en',
         services : {
             youtube : {
+                name: 'YouTube',
                 embedUrl: 'https://www.youtube-nocookie.com/embed/{data-id}',
+                openUrl: 'https://www.youtube.com/watch?v={data-id}',
                 thumbnailUrl: 'https://i3.ytimg.com/vi/{data-id}/hqdefault.jpg',
                 iframe : {
                     allow : 'accelerometer; encrypted-media; gyroscope; picture-in-picture; fullscreen;',
@@ -306,7 +320,8 @@ Both `acceptService` and `rejectService` work the same way:
                     en : {
                         notice: 'This content is hosted by a third party. By showing the external content you accept the <a rel="noreferrer" href="https://www.youtube.com/t/terms" title="Terms and conditions" target="_blank">terms and conditions</a> of youtube.com.',
                         loadBtn: 'Load video',
-                        loadAllBtn: 'Don\'t ask again'
+                        loadAllBtn: 'Don\'t ask again',
+                        openBtn: 'Watch on YouTube'
                     }
                 }
             }
@@ -324,6 +339,7 @@ Both `acceptService` and `rejectService` work the same way:
         currLang: 'en',
         services : {
             dailymotion : {
+                name: 'DailyMotion',
                 embedUrl: 'https://www.dailymotion.com/embed/video/{data-id}',
                 
                 // Use dailymotion api to obtain thumbnail
@@ -407,6 +423,9 @@ Both `acceptService` and `rejectService` work the same way:
     </p>
     </details>
 -   <details><summary>How to embed twitch videos/streams/chats</summary>
+
+    Set the data-id to `channel=<twitch_channel_here>` (channel/video/collection).
+
     <p>
 
     ```javascript
@@ -427,7 +446,8 @@ Both `acceptService` and `rejectService` work the same way:
                     'en' : {
                         notice: 'This content is hosted by a third party. By showing the external content you accept the <a rel="noreferrer" href="https://www.twitch.tv/p/en/legal/terms-of-service/" title="Terms and conditions" target="_blank">terms and conditions</a> of twitch.com.',
                         loadBtn: 'Load stream',
-                        loadAllBtn: 'Don\'t ask again'
+                        loadAllBtn: 'Don\'t ask again',
+                        openBtn: 'Watch on Twitch'
                     }
                 }
             }

--- a/demo/app.js
+++ b/demo/app.js
@@ -9,7 +9,9 @@
 		// autoLang: true,
 		services : {
 			youtube : {
+				name: 'YouTube',
 				embedUrl: 'https://www.youtube-nocookie.com/embed/{data-id}',
+				openUrl: 'https://www.youtube.com/watch?v={data-id}',
 				
 				iframe : {
 					allow : 'accelerometer; encrypted-media; gyroscope; picture-in-picture; fullscreen;',
@@ -21,12 +23,15 @@
 					'en' : {
 						notice: 'This content is hosted by a third party. By showing the external content you accept the <a rel="noreferrer" href="https://www.youtube.com/t/terms" title="Terms and conditions" target="_blank">terms and conditions</a> of youtube.com.',
 						loadBtn: 'Load video',
-						loadAllBtn: 'Don\'t ask again'
+						loadAllBtn: 'Don\'t ask again',
+						openBtn: 'Watch on YouTube'
 					}
 				}
 			},
 			dailymotion : {
+				name: 'DailyMotion',
 				embedUrl: 'https://www.dailymotion.com/embed/video/{data-id}',
+				openUrl: 'https://www.dailymotion.com/video/{data-id}',
 				
 				// Use dailymotion api to obtain thumbnail
 				thumbnailUrl: function(id, setThumbnail){
@@ -109,6 +114,7 @@
 			},
 
 			"facebook-post" : {
+				name: 'Facebook',
 				embedUrl : 'https://www.facebook.com/plugins/post.php?{data-id}',
 
 				iframe : {
@@ -129,6 +135,7 @@
 
 			facebook : {
 				embedUrl : "https://www.facebook.com/",
+				openUrl: "https://www.facebook.com/{data-id}",
 
 				onAccept: function(div, callback){
 
@@ -139,8 +146,8 @@
 					div.appendChild(fbVideo);
 					
 					manager.loadScript('https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v11.0', function(){
-						var c = document.querySelector(`[data-id="${div.dataset.id}"`).lastChild;
-						FB.XFBML.parse(document.querySelector(`[data-id="${div.dataset.id}"`));
+						var c = document.querySelector(`[data-id="${div.dataset.id}"]`).lastChild;
+						FB.XFBML.parse(document.querySelector(`[data-id="${div.dataset.id}"]`));
 						
 						manager.observe(fbVideo, function(iframe){
 							console.log("wwwaaaa", iframe);

--- a/demo/index.html
+++ b/demo/index.html
@@ -41,6 +41,9 @@
             data-service="youtube"
             data-ratio="9:16"
             data-id="fJ9rUzIMcZQ">
+            <a href="https://www.youtube.com/watch?v=fJ9rUzIMcZQ" target="_blank" rel="noopener">
+                Watch on YouTube
+            </a>
         </div>
 		
 		<br>
@@ -50,7 +53,10 @@
 		<div
             data-service="youtube" 
             data-id="fJ9rUzIMcZQ" 
-			data-autoscale>
+            data-autoscale>
+            <a href="https://www.youtube.com/watch?v=fJ9rUzIMcZQ" target="_blank" rel="noopener">
+                Watch on YouTube
+            </a>
         </div>
 		<br>
 
@@ -58,35 +64,48 @@
             data-service="twitter"
             data-id="1404125474981298177"
             data-customwidget
-            style="height: 518px;">
+            data-style="height: 518px;">
+            This is inline HTML which will be removed when JS is allowed.
+            You can use this space to link the public URL, for example
+            <a href="https://twitter.com/orestbida/status/1404125474981298177" target="_blank" rel="noopener">like this</a>.
+            Your website will then be more accessible, plus you will get an automatic open link so you don't need to fill `data-open-url`.
         </div>
 
         <div 
             data-service="twitter"
             data-id="1429246345668304898"
             data-customwidget
-            style="height: 285px;">
+            data-style="height: 285px;">
+            <a href="https://twitter.com/sza/status/1429246345668304898" target="_blank" rel="noopener">
+                Read on Twitter
+            </a>
         </div>
 
         <div 
             data-service="twitter"
             data-id="1429246345668304898"
             data-customwidget
-            style="height: 285px;">
+            data-style="height: 285px;">
+            <a href="https://twitter.com/orestbida/status/1404125474981298177" target="_blank" rel="noopener">
+                Read on Twitter
+            </a>
         </div>
 
         <br>
         <br>
 		<br>
-		<h2>Example with custom thumbnail + params (video starts muted at 21s)</h2>
+		<h2>Example with custom thumbnail + params (video starts muted at 21s with autoplay)</h2>
 		<br>
         <div 
             data-service="youtube" 
             data-id="861gfPVmgdc"
-			data-params="start=21&mute=1"
+			data-params="start=21&mute=1&autoplay=1"
 			data-thumbnail="https://i.pinimg.com/originals/0a/4d/cb/0a4dcb92fa2d3c601b58d72720d6bec4.jpg"
             data-thumbnailpreload
             data-autoscale >
+            <a href="https://www.youtube.com/watch?v=861gfPVmgdc?t=21" target="_blank" rel="noopener">
+                Watch on YouTube
+            </a>
         </div>
 		<br>
 		<br>
@@ -95,7 +114,11 @@
         <div 
             data-service="dailymotion" 
             data-id="x81n4gf"
+            data-open-url="https://example.com/"
             data-autoscale >
+            <a href="https://www.dailymotion.com/video/x81n4gf" target="_blank" rel="noopener">
+                Watch on DailyMotion
+            </a>
         </div>
 
         <br>
@@ -104,19 +127,25 @@
             data-service="facebook"
             data-id="20531316728/posts/10154009990506729/"
             data-title="facebook shit"
-            style="height: 310px; max-width: 350px; width: 100%;"
+            data-style="height: 310px; max-width: 350px; width: 100%;"
             data-customwidget
-            data-autoscale
-        ></div>
+            data-autoscale>
+            <a href="https://www.facebook.com/20531316728/posts/10154009990506729/" target="_blank" rel="noopener">
+                Read on Facebook
+            </a>
+        </div>
         
         <div 
             data-service="facebook-post"
             data-id="href=https://www.facebook.com/nokia/photos/a.338008237396/10157974130297397/&show_text=true&width=500"
             data-title="nokia post"
-            style="height: 453px; max-width: 500px;"
+            data-style="height: 453px; max-width: 500px;"
             data-customwidget
-            data-autoscale
-        ></div>
+            data-autoscale>
+            <a href="https://www.facebook.com/nokia/photos/a.338008237396/10157974130297397/" target="_blank" rel="noopener">
+                Read on Facebook
+            </a>
+        </div>
         <!--
         <iframe src="https://www.facebook.com/plugins/post.php?href=https%3A//www.facebook.com/nokia/photos/a.338008237396/10157974130297397/&show_text=true&width=500" width="500" height="453" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowfullscreen="true" allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"></iframe>
 
@@ -132,7 +161,12 @@
         data-service="twitch"
         data-id="channel=bdougieYO"
         data-title="Twitch channel stream"
-        data-autoscale></div>
+        data-autoscale>
+            <p>
+                This is text which will be shown without JS. Always try to directly link the video/stream here.
+                <br>Also notice that there's no data-open-url or anything so it just links to the embed.
+            </p>
+        </div>
         <br>
         <br>
 

--- a/src/iframemanager.css
+++ b/src/iframemanager.css
@@ -1,6 +1,10 @@
-div[data-service] *,
-div[data-service] :before,
-div[data-service] :after{
+[data-service]{
+	display: block;
+}
+
+[data-js][data-service] *,
+[data-js][data-service] :before,
+[data-js][data-service] :after{
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
     float: none;
@@ -22,7 +26,7 @@ div[data-service] :after{
     text-align: left;
 }
 
-div[data-service] .c-ld {
+[data-service] .c-ld {
 	bottom: 2em;
     right: 2.5em;
 	opacity: 0;
@@ -31,8 +35,8 @@ div[data-service] .c-ld {
 	transition: opacity .3s ease, visibility .3s ease, transform .3s ease;
 }
 
-div[data-service] .c-ld,
-div[data-service] .c-ld:after{
+[data-service] .c-ld,
+[data-service] .c-ld:after{
 	position: absolute;
     z-index: 1;
     border-radius: 100%;
@@ -40,14 +44,14 @@ div[data-service] .c-ld:after{
     height: 20px;
 }
 
-div[data-service] .c-ld::after{
+[data-service] .c-ld::after{
 	content: '';
 	border: 4px solid white;
     border-top: 4px solid transparent;
 	animation: spin 1s linear infinite;
 }
 
-div[data-service].c-h-n .c-ld{
+[data-service].c-h-n .c-ld{
 	opacity: 1;
 	visibility: visible;
 	transform: translateY(0);
@@ -58,7 +62,7 @@ div[data-service].c-h-n .c-ld{
 	100% { transform: rotate(360deg); }
 }
 
-div[data-service]{
+[data-js][data-service]{
 	display: inline-block;
 	max-width: 100%;
 	min-height: 150px;
@@ -69,28 +73,28 @@ div[data-service]{
 	background-color: #0b1016;
 }
 
-div[data-service] button,
-div[data-service] label,
-div[data-service] input,
-div[data-service] h1,
-div[data-service] h2,
-div[data-service] h3{
+[data-service] button,
+[data-service] label,
+[data-service] input,
+[data-service] h1,
+[data-service] h2,
+[data-service] h3{
 	transition: none;
 	animation: none;
 }
 
-div[data-service]::before{
+[data-js][data-service]::before{
 	padding-top: 56.25%;
 	display: block;
 	content: "";
 }
 
-div[data-autoscale]{
+[data-autoscale]{
 	height: auto;
 	width: 100%;
 }
 
-div[data-service] .c-nt{
+[data-service] .c-nt{
 	color: #fff;
 	max-width: 100%;
 	height: 100%;
@@ -104,7 +108,7 @@ div[data-service] .c-nt{
 	z-index: 2;
 }
 
-div[data-service] .c-bg{
+[data-service] .c-bg{
     position: absolute;
     top: 0;
     right: 0;
@@ -115,7 +119,7 @@ div[data-service] .c-bg{
 	transition: opacity .3s ease, visibility .3s ease, transform .3s ease;
 }
 
-div[data-service] .c-bg::before{
+[data-service] .c-bg::before{
 	content: '';
 	position: absolute;
 	top: 0;
@@ -132,7 +136,7 @@ div[data-service] .c-bg::before{
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#1e3861",endColorstr="#cedce9",GradientType=1);
 }
 
-div[data-service] .c-bg-i{
+[data-service] .c-bg-i{
 	background-size: cover;
     background-position: center;
 	background-repeat: no-repeat;
@@ -145,11 +149,11 @@ div[data-service] .c-bg-i{
 	transition: opacity .5s ease, transform .5s ease;
 }
 
-div[data-service] .c-bg-i.loaded{
+[data-service] .c-bg-i.loaded{
 	opacity: 1;
 }
 
-div[data-service] .c-tl{
+[data-service] .c-tl{
     display: block;
     margin-bottom: 10px;
     font-size: 1.2em;
@@ -157,17 +161,17 @@ div[data-service] .c-tl{
 	text-align: center;
 }
 
-div[data-service].c-h-n .c-bg{
+[data-service].c-h-n .c-bg{
 	opacity: 1;
 	transform: scale(1);
 }
 
-div[data-service].c-h-n .c-nt{
+[data-service].c-h-n .c-nt{
 	opacity: 0;
 	visibility: hidden;
 }
 
-div[data-service] .c-n-c{
+[data-service] .c-n-c{
 	display: table;
 	height: 100%;
 	width: 100%;
@@ -178,7 +182,7 @@ div[data-service] .c-n-c{
 	transition: background-color .3s ease, opacity .3s ease;
 }
 
-div[data-service] .c-n-t{
+[data-service] .c-n-t{
 	display: block;
 	font-size: .95em;
 	position: relative;
@@ -190,38 +194,38 @@ div[data-service] .c-n-t{
 	margin-bottom: 20px;
 }
 
-div[data-service] .c-n-t,
-div[data-service] .c-n-a{
-	text-align: center;
+/* [data-service] .c-n-t, */
+[data-service] .c-n-a{
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	align-content: center;
+	gap: 1em;
 }
 
-div[data-service] .c-t-cn{
+[data-service] .c-t-cn{
 	display: table-cell;
 	vertical-align: middle;
 	padding: 0 12px;
 	transition: opacity .3s ease, transform .3s ease, visibility .3s ease;
 }
 
-div[data-service] .c-n-c .c-la-b,
-div[data-service] .c-n-c .c-l-b{
-    display: inline-block;
+[data-service] .c-n-c .c-n-a > *{
     position: relative;
     padding: 1em;
-    vertical-align: middle;
     background: rgba(0, 102, 219, 0.84);
     border: none;
     border-radius: .25em;
     font-size: .85em;
     padding-left: 2.8em;
     color: #ffffff;
-    margin: 0 auto;
     font-weight: bold;
     cursor: pointer;
     transition: opacity .3s ease, transform .3s cubic-bezier(0.25, 1, 0.5, 1), visibility .3s ease, box-shadow .3s ease, background-color .3s ease;
     box-shadow: rgba(0, 0, 0, 0.19) 0px 4px 12px;
 }
 /* Play icon */
-div[data-service] .c-n-c .c-l-b::before{
+[data-service] .c-n-c .c-l-b::before{
 	content: '';
     display: block;
     position: absolute;
@@ -235,38 +239,39 @@ div[data-service] .c-n-c .c-l-b::before{
     border-bottom: 7.5px solid transparent;
 }
 
-div[data-service] .c-n-c .c-la-b{
-    margin-left: 1em;
+[data-service] .c-n-c .c-la-b,
+[data-service] .c-n-c .c-os-b{
 	padding: 1em;
     background: rgba(225, 239, 255, .8);
     color: #0d1f34;
 }
 
-div[data-service] .c-n-c .c-la-b:hover{
+[data-service] .c-n-c .c-la-b:hover,
+[data-service] .c-n-c .c-os-b:hover{
 	background: rgba(225, 239, 255, .95);
 }
 
-div[data-service] .c-n-c .c-l-b:hover{
+[data-service] .c-n-c .c-l-b:hover{
 	background: rgba(9, 80, 161, 0.89);
 }
 
-div[data-service] .c-n-c .c-la-b:active{
+[data-service] .c-n-c .c-la-b:active{
 	transition: none;
     background: rgba(225, 239, 255, .6);
 }
 
-div[data-service] .c-n-c .c-l-b:active{
+[data-service] .c-n-c .c-l-b:active{
 	transition: none;
     box-shadow: 0 0 0 4px rgba(24, 104, 250, .24);
 }
 
-div[data-service].c-h-n .c-t-cn{
+[data-service].c-h-n .c-t-cn{
 	opacity: 0;
 	visibility: hidden;
 	transform: translateY(-10px);
 }
 
-div[data-service] iframe{
+[data-service] iframe{
     position: absolute;
     top: 0;
     left: 0;
@@ -284,97 +289,97 @@ div[data-service] iframe{
 	transition: opacity .5s ease;
 }
 
-div[data-service].c-h-b iframe{
+[data-service].c-h-b iframe{
 	opacity: 1;
 	visibility: visible;
 	transform: scale(1);
 	transition-delay: .1s;
 }
 
-div[data-service] .c-n-t a {
+[data-service] .c-n-t a {
     color: #5fb3fb;
     text-decoration: none;
     border-bottom: 1px solid #5fb3fb;
 }
 
-div[data-service] .c-n-t a:hover{
+[data-service] .c-n-t a:hover{
 	border-color: transparent;
 }
 
-div[data-service][data-ratio="1:1"]::before{
+[data-js][data-service][data-ratio="1:1"]::before{
 	padding-top: 100%;
 }
 
-div[data-service][data-ratio="2:1"]::before{
+[data-js][data-service][data-ratio="2:1"]::before{
 	padding-top: 50%;
 }
 
-div[data-service][data-ratio="3:2"]::before{
+[data-js][data-service][data-ratio="3:2"]::before{
 	padding-top: 66.666666%;
 }
 
-div[data-service][data-ratio="5:2"]::before{
+[data-js][data-service][data-ratio="5:2"]::before{
 	padding-top: 40%;
 }
 
-div[data-service][data-ratio="4:3"]::before{
+[data-js][data-service][data-ratio="4:3"]::before{
 	padding-top: 75%;
 }
 
-div[data-service][data-ratio="16:9"]::before{
+[data-js][data-service][data-ratio="16:9"]::before{
 	padding-top: 56.25%;
 }
 
-div[data-service][data-ratio="16:10"]::before{
+[data-js][data-service][data-ratio="16:10"]::before{
 	padding-top: 62.5%;
 }
 
-div[data-service][data-ratio="20:9"]::before{
+[data-js][data-service][data-ratio="20:9"]::before{
 	padding-top: 45%;
 }
 
-div[data-service][data-ratio="21:9"]::before{
+[data-js][data-service][data-ratio="21:9"]::before{
 	padding-top: 42.857142%;
 }
 
 /** Vertical aspect ratios **/
-div[data-service][data-ratio="9:16"]::before{
+[data-js][data-service][data-ratio="9:16"]::before{
 	padding-top: 177.777777%;
 }
 
-div[data-service][data-ratio="9:20"]::before{
+[data-js][data-service][data-ratio="9:20"]::before{
 	padding-top: 222.222222%;
 }
 
-div[data-customwidget]::before {
+[data-js][data-customwidget]::before {
 	display: none;
 }
 
-div[data-customwidget].c-h-b{
+[data-js][data-customwidget].c-h-b{
 	background: transparent;
 }
 
-div[data-customwidget].c-h-b .c-ld{
+[data-js][data-customwidget].c-h-b .c-ld{
 	opacity: 0;
 	visibility: hidden;
 }
 
-div[data-customwidget] > div{
+[data-js][data-customwidget] > div{
 	margin: 0!important;
 }
 
-div[data-customwidget]{
+[data-js][data-customwidget]{
 	vertical-align: top;
 	min-width: 296px;
 	transition: background-color .3s ease;
 	transition-delay: .3s;
 }
 
-div[data-service="twitter"] .c-n-c .c-l-b{
+[data-service="twitter"] .c-n-c .c-l-b{
 	background-color: #1DA1F2;
 }
 
-div[data-service="twitter"] .c-n-c .c-l-b::before{
+[data-service="twitter"] .c-n-c .c-l-b::before{
 	border: none;
 	height: 15px;
 	width: 15px;


### PR DESCRIPTION
I wanted to make the iframemanager accessible without JS and add a direct link to the website, so here's a PR for that. New features:

### Allows using any HTML tag

You can now use any HTML tag and not just `<div>`.

### Works without JS

Without JS, the page can show any content inside the element, e.g. a normal link to a YouTube video.  
When JS is enabled, everything in `innerHTML` automatically gets removed.

```html
<div
    data-service="youtube"
    data-ratio="9:16"
    data-id="fJ9rUzIMcZQ">
    <a href="https://www.youtube.com/watch?v=fJ9rUzIMcZQ" target="_blank" rel="noopener">
        Watch on YouTube
    </a>
</div>
```

There is also a new attribute `data-style` to allow inline styling for the frame only when JS is enabled, to prevent showing large empty containers when JS is disabled.

### Direct link when consent is not set

This shows a new "Open SERVICE_NAME" button next to the Load and Don't ask again buttons.

You can either set a link with the `data-open-url` attribute or, if you have the `href` attribute on the element or in any child element, it takes it automatically from there.

Service name is set in service definition under the `name` key, If not set, defaults to the capitalized key of the service definition.  
Alternatively, you can change the text shown with the `openBtn` string in `language` config.