### PR TITLE
Create reset function for re-render issues

### DIFF
--- a/src/iframemanager.js
+++ b/src/iframemanager.js
@@ -742,6 +742,16 @@
         });
     };
 
+    const clearObservers = () => {
+        for (const serviceName in serviceObservers) {
+            if (Object.hasOwnProperty.call(serviceObservers, serviceName)) {
+                const observer = serviceObservers[serviceName];
+
+                observer.disconnect();
+            }
+        }
+    };
+
     const api = {
 
         /**
@@ -856,6 +866,25 @@
         }),
 
         getConfig: () => config,
+
+        reset: () => {
+            clearObservers()
+
+            win = undefined
+            doc = undefined
+            config = undefined
+            services = undefined
+            onChangeCallback = undefined
+            allServiceProps = {}
+            serviceObservers = {}
+            stopServiceObserver = {}
+            currLang = ''
+            services = {}
+            serviceNames = undefined
+            servicesState = new Map()
+            currentEventSource = API_EVENT_SOURCE
+            onChangeCallback = undefined
+        },
 
         run: (_config) => {
 


### PR DESCRIPTION
The plugin cannot detect DOM changes, indeed keeps the previous one. This is a clean solution that does not affect the expected operation. There are cases when you need to reset the entire script, this helps. #48

Example:
```js
import { useRouter } from 'next/router'
...

useEffect(() => {
  // const cc = initCookieConsent()
  const im = iframemanager()
 
  setTimeout(() => {
      im.run(...)
  }, 1000) // Since it is not SSR, it is necessary to allow time for the client to render it

  return () => {
    im.reset() // stop observers, reset scoped variables
  }
}, [router.asPath])
...
```