### PR TITLE
Make embedUrl an optional callback

### DIFF
--- a/src/iframemanager.js
+++ b/src/iframemanager.js
@@ -48,7 +48,7 @@
 
     /**
      * @typedef {Object} ServiceConfig
-     * @property {string} embedUrl
+     * @property {string|Function<string>} embedUrl
      * @property {string | () => string} [thumbnailUrl]
      * @property {IframeProp} [iframe]
      * @property {CookieStructure} cookie
@@ -346,7 +346,10 @@
         const iframeParams = serviceProp._params || iframeConfig && iframeConfig.params;
 
         // Replace data-id with valid resource id
-        const embedUrl = serviceConfig.embedUrl || '';
+        let embedUrl = serviceConfig.embedUrl || '';
+        if (isFunction(embedUrl)) {
+            embedUrl = String(embedUrl());
+        }
         let src = embedUrl.replace(DATA_ID_PLACEHOLDER, serviceProp._id);
 
         serviceProp._title && (serviceProp._iframe.title = serviceProp._title);

--- a/src/iframemanager.js
+++ b/src/iframemanager.js
@@ -47,8 +47,13 @@
      */
 
     /**
+     * @callback embedUrlCallback
+     * @return {string}
+     */
+
+    /**
      * @typedef {Object} ServiceConfig
-     * @property {string|Function<string>} embedUrl
+     * @property {string | embedUrlCallback} embedUrl
      * @property {string | () => string} [thumbnailUrl]
      * @property {IframeProp} [iframe]
      * @property {CookieStructure} cookie


### PR DESCRIPTION
This is a small tweak meant to allow constructing the embedUrl programmatically.

Here is an example of how it could be used in combination with CookieConsent, based on the [StackBlitz example](https://stackblitz.com/edit/web-platform-ahqgz3?file=index.js).
Depending on the user consent for the 'vimeo_analytics' service, the Do Not Track URL parameter for Vimeo is appended to the URL:
```JavaScript
const im = iframemanager();

im.run({
    onChange: ({changedServices, eventSource}) => {
        if (eventSource.type === 'click') {
            // ...
        }
    },

    currLang: 'en',

    services: {
        vimeo: {
            // embedUrl: 'https://player.vimeo.com/video/{data-id}',
            embedUrl: () => {
                return CookieConsent.acceptedService('vimeo_analytics', 'analytics') ?
                    'https://player.vimeo.com/video/{data-id}'
                    : 'https://player.vimeo.com/video/{data-id}?dnt=1';
            },
            iframe: {
                allow: 'fullscreen; picture-in-picture;',
            },

            thumbnailUrl: 'https://example.com/img/vimeo-placeholder.jpg',

            languages: {
                en: {
                    notice:
                        'This content is hosted by a third party. By showing the external content you accept the <a rel="noreferrer noopener" href="https://vimeo.com/terms" target="_blank">terms and conditions</a> of vimeo.com.',
                    loadBtn: 'Load once',
                    loadAllBtn: "Don't ask again",
                },
            },
        },
    },
});
```